### PR TITLE
Add R6 to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,8 +52,9 @@ LinkingTo:
     Rcpp, 
     RcppArmadillo (>= 0.9.100.5.0)
 Suggests: 
-    testthat, 
-    covr
+    testthat,
+    covr,
+    R6
 StagedInstall: TRUE
 URL: https://github.com/dselivanov/rsparse
 BugReports: https://github.com/dselivanov/rsparse/issues


### PR DESCRIPTION
Closes #80 

R doesn't have a good system for requiring such dependencies, I think `Suggests` is the best compromise within the current system.